### PR TITLE
Bundle optimizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "react-dom": "^19.0.0",
         "react-modal": "^3.16.1",
         "react-router-dom": "^7.4.0",
-        "sigma": "^3.0.1",
-        "typescript": "^5.5.4"
+        "sigma": "^3.0.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.24.8",
@@ -44,7 +43,9 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "style-loader": "^4.0.0",
+        "typescript": "^5.8.2",
         "webpack": "^5.93.0",
+        "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^5.1.4"
       }
     },
@@ -2331,6 +2332,12 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
+    },
     "node_modules/@react-sigma/core": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@react-sigma/core/-/core-5.0.2.tgz",
@@ -3854,6 +3861,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -4051,6 +4064,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.120",
@@ -4655,6 +4674,21 @@
       "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
       "peerDependencies": {
         "graphology-types": ">=0.23.0"
+      }
+    },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/has-flag": {
@@ -6431,6 +6465,15 @@
         "node": "*"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6563,6 +6606,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/p-limit": {
@@ -7484,6 +7536,20 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7810,6 +7876,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -7872,6 +7947,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8094,6 +8170,74 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
+      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/react-router-dom": "^5.3.3",
         "babel-loader": "^9.1.3",
         "css-loader": "^7.1.2",
+        "html-webpack-plugin": "^5.6.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "style-loader": "^4.0.0",
@@ -2585,6 +2586,12 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
     },
+    "node_modules/@types/html-minifier-terser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+      "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
+      "dev": true
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3320,6 +3327,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3409,6 +3422,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/camelcase": {
@@ -3519,6 +3542,18 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -3730,6 +3765,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -3879,6 +3942,50 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
     },
+    "node_modules/dom-converter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+      "dev": true,
+      "dependencies": {
+        "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -3890,6 +3997,45 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/dunder-proto": {
@@ -4559,6 +4705,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -4576,6 +4731,96 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html-minifier-terser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+      "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "^5.2.2",
+        "commander": "^8.3.0",
+        "he": "^1.2.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.10.0"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/html-webpack-plugin": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.3.tgz",
+      "integrity": "sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==",
+      "dev": true,
+      "dependencies": {
+        "@types/html-minifier-terser": "^6.0.0",
+        "html-minifier-terser": "^6.0.2",
+        "lodash": "^4.17.21",
+        "pretty-error": "^4.0.0",
+        "tapable": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/html-webpack-plugin"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "webpack": "^5.20.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -6049,6 +6294,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6213,6 +6467,16 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6244,6 +6508,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nwsapi": {
@@ -6340,6 +6616,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -6368,6 +6654,16 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -6641,6 +6937,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/pretty-error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+      "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.20",
+        "renderkid": "^3.0.0"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
@@ -6947,6 +7253,28 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/renderkid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+      "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^6.0.1"
       }
     },
     "node_modules/require-directory": {
@@ -7651,6 +7979,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "portfolio website",
   "main": "index.tsx",
   "scripts": {
-    "build": "webpack build --mode production --env buildForProd=true",
-    "start": "webpack build --watch --mode development --env buildForProd=true",
+    "build": "NODE_ENV=production webpack build --mode production",
+    "start": "NODE_ENV=development webpack build --watch --mode development",
+    "analyze": "NODE_ENV=production webpack build --watch --mode production --env analyze=true",
     "test": "jest"
   },
   "author": "00-status",
@@ -30,7 +31,9 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "style-loader": "^4.0.0",
+    "typescript": "^5.8.2",
     "webpack": "^5.93.0",
+    "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
@@ -46,7 +49,6 @@
     "react-dom": "^19.0.0",
     "react-modal": "^3.16.1",
     "react-router-dom": "^7.4.0",
-    "sigma": "^3.0.1",
-    "typescript": "^5.5.4"
+    "sigma": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/react-router-dom": "^5.3.3",
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
+    "html-webpack-plugin": "^5.6.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "style-loader": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NODE_ENV=production webpack build --mode production",
     "start": "NODE_ENV=development webpack build --watch --mode development",
-    "analyze": "NODE_ENV=production webpack build --watch --mode production --env analyze=true",
+    "analyze": "NODE_ENV=production webpack build --mode production --env analyze=true",
     "test": "jest"
   },
   "author": "00-status",

--- a/src/AboutMe/AboutMe.test.tsx
+++ b/src/AboutMe/AboutMe.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import { Children } from "react";
 
-import { AboutMe } from "./AboutMe";
+import AboutMe from "./AboutMe";
 
 jest.mock('../SharedComponents/Page/Page', () => {
     return {

--- a/src/AboutMe/AboutMe.tsx
+++ b/src/AboutMe/AboutMe.tsx
@@ -6,7 +6,7 @@ import { Skill, skills } from "./domain";
 import { SkillCard } from "./SkillCard";
 import { Anchor } from "../SharedComponents/Link/Anchor";
 
-export const AboutMe = (): ReactElement => {
+const AboutMe = (): ReactElement => {
     const routes = [
         { label: 'Landing', route: '/', isHomeLink: true },
         { label: 'D&D Tools', route: '/dnd_tools/dice_roller' },
@@ -33,3 +33,5 @@ export const AboutMe = (): ReactElement => {
         </div>
     </Page>;
 };
+
+export default AboutMe;

--- a/src/DNDTools/DiceRoller/DiceRoller.test.tsx
+++ b/src/DNDTools/DiceRoller/DiceRoller.test.tsx
@@ -3,7 +3,7 @@ import { Children } from "react";
 import userEvent from "@testing-library/user-event";
 import * as GTAG from "ga-gtag";
 
-import { DiceRoller } from "./DiceRoller";
+import DiceRoller from "./DiceRoller";
 
 jest.mock('../../SharedComponents/Page/Page', () => {
     return {

--- a/src/DNDTools/DiceRoller/DiceRoller.tsx
+++ b/src/DNDTools/DiceRoller/DiceRoller.tsx
@@ -8,7 +8,7 @@ import { CustomDiceRoller } from "./CustomDiceRoller";
 import { dndRoutes } from "../domain";
 import { Anchor } from "../../SharedComponents/Link/Anchor";
 
-export const DiceRoller = (): ReactElement => {
+const DiceRoller = (): ReactElement => {
     const [animationKey, setAnimationKey] = useState<number>(0);
 
     const [generatedNumber, setGeneratedNumber] = useState<number|null>(null);
@@ -83,3 +83,5 @@ const dice: Array<number> = [
     12,
     20
 ];
+
+export default DiceRoller;

--- a/src/DNDTools/DnDShop/DnDShop.tsx
+++ b/src/DNDTools/DnDShop/DnDShop.tsx
@@ -15,7 +15,7 @@ import { dndRoutes } from "../domain";
 
 export type CartSlot = { droppableID: string, item: null | Item };
 
-export const DndShop = () => {
+const DndShop = () => {
     const [playerCurrency, setPlayerCurrency] = useState<Currency>({ gold: 0, silver: 0, copper: 0 });
     const [cartSlots, setCartSlots] = useState<CartSlot[]>(generateEmptyCartSlots(0, 3));
     const [currentItem, setCurrentItem] = useState<{ name: string, cost: number, currency: string } | null>(null);
@@ -89,3 +89,5 @@ export const DndShop = () => {
         </div>
     </Page>;
 };
+
+export default DndShop;

--- a/src/DNDTools/WeaponMaker/WeaponMaker.tsx
+++ b/src/DNDTools/WeaponMaker/WeaponMaker.tsx
@@ -12,7 +12,7 @@ import { Loader } from '../../SharedComponents/Loader/Loader';
 import { Icon } from '../../SharedComponents/Icon/Icon';
 import { IconType } from '../../SharedComponents/Icon/domain';
 
-export const WeaponMaker = () => {
+const WeaponMaker = () => {
     const [selectedRarity, setSelectedRarity] = useState<string>("Uncommon");
 
     const {weapon, generateWeapon, isLoading} = useGenerateWeapon();
@@ -57,3 +57,5 @@ export const WeaponMaker = () => {
         </div>
     </Page>;
 };
+
+export default WeaponMaker;

--- a/src/ErrorStates/ErrorBoundary.tsx
+++ b/src/ErrorStates/ErrorBoundary.tsx
@@ -3,11 +3,10 @@ import { useEffect } from "react";
 
 import './route-error-boundary.css';
 import { Button } from "../SharedComponents/Button/Button";
-import { HomeIcon } from "../SharedComponents/Icon/Icons/HomeIcon";
 import { Icon } from "../SharedComponents/Icon/Icon";
 import { IconType } from '../SharedComponents/Icon/domain';
 
-export const RouterErrorBoundary = () => {
+const RouterErrorBoundary = () => {
     const error = useRouteError();
 
     useEffect(() => {
@@ -28,4 +27,6 @@ export const RouterErrorBoundary = () => {
             </Button>
         </div>
     </div>;
-}
+};
+
+export default RouterErrorBoundary;

--- a/src/ErrorStates/NotFoundPage.tsx
+++ b/src/ErrorStates/NotFoundPage.tsx
@@ -2,7 +2,7 @@
 import './not-found-page.css';
 import { Page } from "../SharedComponents/Page/Page";
 
-export const NotFoundPage = () => {
+const NotFoundPage = () => {
     const routes = [
         { label: 'Landing', route: '/', isHomeLink: true }
     ];
@@ -12,3 +12,5 @@ export const NotFoundPage = () => {
         </div>
     </Page>;
 };
+
+export default NotFoundPage;

--- a/src/HiddenPages/TerminalEditor/TerminalEditorPage.tsx
+++ b/src/HiddenPages/TerminalEditor/TerminalEditorPage.tsx
@@ -10,7 +10,7 @@ import { Directory, useDirectories } from "../../Terminal/hooks/directories/useD
 import { Loader } from "../../SharedComponents/Loader/Loader";
 import { DirectoryEditor } from "./DirectoryEditor";
 
-export const TerminalEditorPage = () => {
+const TerminalEditorPage = () => {
     const [newServerName, setNewServerName] = useState<string>("");
     const [selectedServerId, setSelectedServerId] = useState<number|null>(null);
 
@@ -119,3 +119,5 @@ export const TerminalEditorPage = () => {
         </div>
     </Page>;
 };
+
+export default TerminalEditorPage;

--- a/src/HiddenPages/WeaponEffectEditor/WeaponEffectList.tsx
+++ b/src/HiddenPages/WeaponEffectEditor/WeaponEffectList.tsx
@@ -1,10 +1,11 @@
+import { useEffect, useState } from "react";
+
 import './weapon-effect-list.css';
 import { Page } from "../../SharedComponents/Page/Page";
 import { useFetchWeaponEffect } from "./useFetchWeaponEffect";
 import { WeaponEffect, WeaponEffectForm } from "../WeaponEffectEditor/WeaponEffectForm";
-import { useEffect, useState } from "react";
 
-export const WeaponEffectList = () => {
+const WeaponEffectList = () => {
     const { weaponEffects, fetchWeaponEffects} = useFetchWeaponEffect();
 
     const [currentWeaponEffect, setCurrentWeaponEffect] = useState<WeaponEffect|null>(null);
@@ -37,3 +38,5 @@ export const WeaponEffectList = () => {
         </div>
     </Page>
 };
+
+export default WeaponEffectList;

--- a/src/RPGTools/CharacterMaker/CharacterMaker.tsx
+++ b/src/RPGTools/CharacterMaker/CharacterMaker.tsx
@@ -5,7 +5,7 @@ import { Page } from "../../SharedComponents/Page/Page";
 import { useCharacters } from "./useCharacters";
 import { RPGRoutes } from '../domain';
 
-export const CharacterMaker = () => {
+const CharacterMaker = () => {
     const { characters, setCharacters } = useCharacters();
 
     return <Page title="RPG Tools" routes={RPGRoutes}>
@@ -17,3 +17,5 @@ export const CharacterMaker = () => {
         </div>
     </Page>;
 };
+
+export default CharacterMaker;

--- a/src/RPGTools/DialogueTreeMaker/DialogueTreeMaker.tsx
+++ b/src/RPGTools/DialogueTreeMaker/DialogueTreeMaker.tsx
@@ -18,7 +18,7 @@ import { GraphContainer } from "./DialogueTreeGraph/GraphContainer";
 import { Icon } from "../../SharedComponents/Icon/Icon";
 import { IconType } from '../../SharedComponents/Icon/domain';
 
-export const DialogueTreeMaker = (): ReactElement => {
+const DialogueTreeMaker = (): ReactElement => {
     const {
         dialogueTreeID,
         dialogueTreeName,
@@ -187,3 +187,5 @@ export const DialogueTreeMaker = (): ReactElement => {
         </div>
     </Page>;
 };
+
+export default DialogueTreeMaker;

--- a/src/RPGTools/TreePreview/TreePreviewPage.tsx
+++ b/src/RPGTools/TreePreview/TreePreviewPage.tsx
@@ -10,7 +10,7 @@ import { ConditionOutcome } from "../DialogueTreeMaker/domain/types";
 import { HistoryItem } from "./HistoryItem";
 import { Condition, DialogueHistory, PreviewChoice } from "./domain/types";
 
-export const TreePreviewPage = () => {
+const TreePreviewPage = () => {
     const {
         dialogues,
         skillTests
@@ -105,3 +105,5 @@ export const TreePreviewPage = () => {
         </div>
     </Page>;
 };
+
+export default TreePreviewPage;

--- a/src/Terminal/TerminalPage.tsx
+++ b/src/Terminal/TerminalPage.tsx
@@ -13,7 +13,7 @@ import { IconTheme } from '../SharedComponents/Icon/domain';
 import { IconType } from '../SharedComponents/Icon/domain';
 
 
-export const TerminalPage = () => {
+const TerminalPage = () => {
     const navigate = useNavigate();
 
     document.title = "Terminal";
@@ -82,3 +82,5 @@ const changeKey = (array: Array<number|string>, setArray: (newArray: Array<numbe
 
     setArray(arrayCopy);
 };
+
+export default TerminalPage;

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Liam J</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div id="app"></div>
+</body>
+</html>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,17 +6,17 @@ import "@react-sigma/core/lib/style.css";
 
 import { RouterErrorBoundary } from './ErrorStates/ErrorBoundary';
 
-const AboutMe = lazy(() => import('./AboutMe/AboutMe'));
-const DiceRoller = lazy(() => import('./DNDTools/DiceRoller/DiceRoller'));
-const DndShop = lazy(() => import('./DNDTools/DnDShop/DnDShop'));
-const DialogueTreeMaker = lazy(() => import('./RPGTools/DialogueTreeMaker/DialogueTreeMaker'));
-const CharacterMaker = lazy(() => import('./RPGTools/CharacterMaker/CharacterMaker'));
-const NotFoundPage = lazy(() => import('./ErrorStates/NotFoundPage'));
-const TerminalPage = lazy(() => import('./Terminal/TerminalPage'));
-const WeaponMaker = lazy(() => import('./DNDTools/WeaponMaker/WeaponMaker'));
-const WeaponEffectList = lazy(() => import('./HiddenPages/WeaponEffectEditor/WeaponEffectList'));
-const TerminalEditorPage = lazy(() => import('./HiddenPages/TerminalEditor/TerminalEditorPage'));
-const TreePreviewPage = lazy(() => import('./RPGTools/TreePreview/TreePreviewPage'));
+const AboutMe = lazy(() => import(/* webpackChunkName: "about-me" */ './AboutMe/AboutMe'));
+const DiceRoller = lazy(() => import(/* webpackChunkName: "dice-roller" */ './DNDTools/DiceRoller/DiceRoller'));
+const DndShop = lazy(() => import(/* webpackChunkName: "dnd-shop" */ './DNDTools/DnDShop/DnDShop'));
+const DialogueTreeMaker = lazy(() => import(/* webpackChunkName: "dialogue-tree-maker" */ './RPGTools/DialogueTreeMaker/DialogueTreeMaker'));
+const CharacterMaker = lazy(() => import(/* webpackChunkName: "character-maker" */ './RPGTools/CharacterMaker/CharacterMaker'));
+const NotFoundPage = lazy(() => import(/* webpackChunkName: "not-found-page" */ './ErrorStates/NotFoundPage'));
+const TerminalPage = lazy(() => import(/* webpackChunkName: "terminal-page" */ './Terminal/TerminalPage'));
+const WeaponMaker = lazy(() => import(/* webpackChunkName: "weapon-maker" */ './DNDTools/WeaponMaker/WeaponMaker'));
+const WeaponEffectList = lazy(() => import(/* webpackChunkName: "weapon-effect-list" */ './HiddenPages/WeaponEffectEditor/WeaponEffectList'));
+const TerminalEditorPage = lazy(() => import(/* webpackChunkName: "terminal-editor-page" */ './HiddenPages/TerminalEditor/TerminalEditorPage'));
+const TreePreviewPage = lazy(() => import(/* webpackChunkName: "tree-preview-page" */ './RPGTools/TreePreview/TreePreviewPage'));
 
 initDataLayer();
 gtag('consent', 'default', {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,8 +4,6 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { gtag, initDataLayer, install } from 'ga-gtag';
 import "@react-sigma/core/lib/style.css";
 
-import { RouterErrorBoundary } from './ErrorStates/ErrorBoundary';
-
 const AboutMe = lazy(() => import(/* webpackChunkName: "about-me" */ './AboutMe/AboutMe'));
 const DiceRoller = lazy(() => import(/* webpackChunkName: "dice-roller" */ './DNDTools/DiceRoller/DiceRoller'));
 const DndShop = lazy(() => import(/* webpackChunkName: "dnd-shop" */ './DNDTools/DnDShop/DnDShop'));
@@ -17,6 +15,7 @@ const WeaponMaker = lazy(() => import(/* webpackChunkName: "weapon-maker" */ './
 const WeaponEffectList = lazy(() => import(/* webpackChunkName: "weapon-effect-list" */ './HiddenPages/WeaponEffectEditor/WeaponEffectList'));
 const TerminalEditorPage = lazy(() => import(/* webpackChunkName: "terminal-editor-page" */ './HiddenPages/TerminalEditor/TerminalEditorPage'));
 const TreePreviewPage = lazy(() => import(/* webpackChunkName: "tree-preview-page" */ './RPGTools/TreePreview/TreePreviewPage'));
+const RouterErrorBoundary = lazy(() => import(/* webpackChunkName: "about-me" */ './ErrorStates/ErrorBoundary'));
 
 initDataLayer();
 gtag('consent', 'default', {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,20 +1,22 @@
+import { lazy } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { gtag, initDataLayer, install } from 'ga-gtag';
 import "@react-sigma/core/lib/style.css";
 
-import { AboutMe } from './AboutMe/AboutMe';
-import { DiceRoller } from './DNDTools/DiceRoller/DiceRoller';
-import { DndShop } from './DNDTools/DnDShop/DnDShop';
-import { DialogueTreeMaker } from './RPGTools/DialogueTreeMaker/DialogueTreeMaker';
-import { CharacterMaker } from './RPGTools/CharacterMaker/CharacterMaker';
-import { NotFoundPage } from './ErrorStates/NotFoundPage';
-import { TerminalPage } from './Terminal/TerminalPage';
-import { WeaponMaker } from './DNDTools/WeaponMaker/WeaponMaker';
-import { WeaponEffectList } from './HiddenPages/WeaponEffectEditor/WeaponEffectList';
-import { TerminalEditorPage } from './HiddenPages/TerminalEditor/TerminalEditorPage';
-import { TreePreviewPage } from './RPGTools/TreePreview/TreePreviewPage';
 import { RouterErrorBoundary } from './ErrorStates/ErrorBoundary';
+
+const AboutMe = lazy(() => import('./AboutMe/AboutMe'));
+const DiceRoller = lazy(() => import('./DNDTools/DiceRoller/DiceRoller'));
+const DndShop = lazy(() => import('./DNDTools/DnDShop/DnDShop'));
+const DialogueTreeMaker = lazy(() => import('./RPGTools/DialogueTreeMaker/DialogueTreeMaker'));
+const CharacterMaker = lazy(() => import('./RPGTools/CharacterMaker/CharacterMaker'));
+const NotFoundPage = lazy(() => import('./ErrorStates/NotFoundPage'));
+const TerminalPage = lazy(() => import('./Terminal/TerminalPage'));
+const WeaponMaker = lazy(() => import('./DNDTools/WeaponMaker/WeaponMaker'));
+const WeaponEffectList = lazy(() => import('./HiddenPages/WeaponEffectEditor/WeaponEffectList'));
+const TerminalEditorPage = lazy(() => import('./HiddenPages/TerminalEditor/TerminalEditorPage'));
+const TreePreviewPage = lazy(() => import('./RPGTools/TreePreview/TreePreviewPage'));
 
 initDataLayer();
 gtag('consent', 'default', {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,11 @@
 const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
-module.exports = (env) => {    
+module.exports = (env) => {
+  const shouldOpenAnalyzer = env.analyze;
+
   return {
     entry: "./src/index.tsx",
     output: {
@@ -22,8 +25,8 @@ module.exports = (env) => {
         template: './src/index.html',
         inject: 'body',
       }),
+      ...(shouldOpenAnalyzer ? [new BundleAnalyzerPlugin({analyzerMode: 'static', openAnalyzer: true})] : []),
     ],
-    mode: "development",
     module: {
       rules: [
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,17 +1,19 @@
 const path = require("path");
 const webpack = require("webpack");
 
-module.exports = (env) => {
-  const buildPath = env.buildForProd
-    ? path.resolve(__dirname, "../server_php/public/")
-    : path.resolve(__dirname, "dist/");
-
-    
+module.exports = (env) => {    
   return {
     entry: "./src/index.tsx",
     output: {
-      path: buildPath,
-      filename: "bundle.js"
+      path: path.resolve(__dirname, "../server_php/public/"),
+      filename: '[name].[contenthash].js',
+      chunkFilename: '[name].[contenthash].js',
+      clean: true
+    },
+    optimization: {
+      splitChunks: {
+        chunks: "all",
+      }
     },
     mode: "development",
     module: {
@@ -57,3 +59,4 @@ module.exports = (env) => {
     resolve: { extensions: ["*", ".js", ".jsx", ".ts", ".tsx"] }
   };
 }
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,13 @@ module.exports = (env) => {
     optimization: {
       splitChunks: {
         chunks: "all",
+        cacheGroups: {
+          sharedComponents: {
+            test: /[\\/]src[\\/]SharedComponents[\\/]/, // Target the sharedComponents folder
+            name: 'shared-components', // Name of the output bundle
+            chunks: 'all', // Include both synchronous and asynchronous chunks
+          },
+        },
       }
     },
     plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,13 @@
 const path = require("path");
 const webpack = require("webpack");
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = (env) => {    
   return {
     entry: "./src/index.tsx",
     output: {
       path: path.resolve(__dirname, "../server_php/public/"),
+      publicPath: '/public/',
       filename: '[name].[contenthash].js',
       chunkFilename: '[name].[contenthash].js',
       clean: true
@@ -15,6 +17,12 @@ module.exports = (env) => {
         chunks: "all",
       }
     },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: './src/index.html',
+        inject: 'body',
+      }),
+    ],
     mode: "development",
     module: {
       rules: [


### PR DESCRIPTION
resolves #32 

Reduced entry bundle from 716KB to 253KB (280% reduction) by lazy loading react pages and splitting the bundle into chunks, added an analyzer to visually see what bundles have what in them, and split sharedComponents into its own bundle.

There's probably still some optimizations that could be made regarding css imports but this is fine for now. 