### PR TITLE
Kingdom: Tile Traits

### DIFF
--- a/src/Kingdom/Overview/KingdomOverviewPage.tsx
+++ b/src/Kingdom/Overview/KingdomOverviewPage.tsx
@@ -1,9 +1,9 @@
+import { useMemo, useState } from 'react';
 
 import './kingdom-overview-page.css';
 import { Page } from "../../SharedComponents/Page/Page";
-import { useMemo, useState } from 'react';
 import { Tile } from './Tile';
-import { extractCenterGrid, generateWeightedTerrain } from './utli';
+import { extractCenterGrid, generateWeightedTerrain } from './util';
 
 type Kingdom = { name: String, terrain: Terrain };
 export type Terrain = { rowSize: number, columnSize: number, tiles: Array<Tile> };

--- a/src/Kingdom/Overview/KingdomOverviewPage.tsx
+++ b/src/Kingdom/Overview/KingdomOverviewPage.tsx
@@ -5,10 +5,7 @@ import { Page } from "../../SharedComponents/Page/Page";
 import { Tile } from './Tile';
 import { extractCenterGrid, generateWeightedTerrain } from './util';
 import { TileDetails } from './TileDetails';
-
-type Kingdom = { name: String, terrain: Terrain };
-export type Terrain = { rowSize: number, columnSize: number, tiles: Array<Tile> };
-export type Tile = { id: string, x: number, y: number, type: string };
+import { Kingdom, Tile as TileType } from './domain/types';
 
 const terrain = generateWeightedTerrain(11, 11);
 const centerTerrain = extractCenterGrid(terrain, 3);
@@ -19,8 +16,8 @@ const kingdom: Kingdom = {
 };
 
 const KingdomOverviewPage = () => {
-    const [orderedTiles, setOrderedTiles] = useState<Array<Tile>>([]);
-    const [currentTile, setCurrentTile] = useState<Tile|null>(null);
+    const [orderedTiles, setOrderedTiles] = useState<Array<TileType>>([]);
+    const [currentTile, setCurrentTile] = useState<TileType|null>(null);
 
     useMemo(() => {
         const tilesByCoords = kingdom.terrain.tiles.reduce((carry, tile) => {
@@ -28,7 +25,7 @@ const KingdomOverviewPage = () => {
             carry[key] = tile;
     
             return carry;
-        }, {} as {[key: string]: Tile} );
+        }, {} as {[key: string]: TileType} );
 
         const orderedTiles = [];
         for (let y = 0; y < kingdom.terrain.columnSize; y++) {

--- a/src/Kingdom/Overview/KingdomOverviewPage.tsx
+++ b/src/Kingdom/Overview/KingdomOverviewPage.tsx
@@ -6,13 +6,15 @@ import { Tile } from './Tile';
 import { extractCenterGrid, generateWeightedTerrain } from './util';
 import { TileDetails } from './TileDetails';
 import { Kingdom, Tile as TileType } from './domain/types';
+import { addTerrainFeatures } from './domain/addTerrainFeatures';
 
-const terrain = generateWeightedTerrain(11, 11);
+const terrain = generateWeightedTerrain(15, 15);
+const terrainWithFeatures = addTerrainFeatures(terrain);
 const centerTerrain = extractCenterGrid(terrain, 3);
 
 const kingdom: Kingdom = {
     name: "Camelot",
-    terrain: centerTerrain
+    terrain: terrainWithFeatures
 };
 
 const KingdomOverviewPage = () => {

--- a/src/Kingdom/Overview/KingdomOverviewPage.tsx
+++ b/src/Kingdom/Overview/KingdomOverviewPage.tsx
@@ -10,11 +10,11 @@ import { addTerrainFeatures } from './domain/addTerrainFeatures';
 
 const terrain = generateWeightedTerrain(15, 15);
 const terrainWithFeatures = addTerrainFeatures(terrain);
-const centerTerrain = extractCenterGrid(terrain, 3);
+const centerTerrain = extractCenterGrid(terrainWithFeatures, 3);
 
 const kingdom: Kingdom = {
     name: "Camelot",
-    terrain: terrainWithFeatures
+    terrain: centerTerrain
 };
 
 const KingdomOverviewPage = () => {

--- a/src/Kingdom/Overview/KingdomOverviewPage.tsx
+++ b/src/Kingdom/Overview/KingdomOverviewPage.tsx
@@ -4,10 +4,11 @@ import './kingdom-overview-page.css';
 import { Page } from "../../SharedComponents/Page/Page";
 import { Tile } from './Tile';
 import { extractCenterGrid, generateWeightedTerrain } from './util';
+import { TileDetails } from './TileDetails';
 
 type Kingdom = { name: String, terrain: Terrain };
 export type Terrain = { rowSize: number, columnSize: number, tiles: Array<Tile> };
-export type Tile = { x: number, y: number, type: string };
+export type Tile = { id: string, x: number, y: number, type: string };
 
 const terrain = generateWeightedTerrain(11, 11);
 const centerTerrain = extractCenterGrid(terrain, 3);
@@ -19,6 +20,7 @@ const kingdom: Kingdom = {
 
 const KingdomOverviewPage = () => {
     const [orderedTiles, setOrderedTiles] = useState<Array<Tile>>([]);
+    const [currentTile, setCurrentTile] = useState<Tile|null>(null);
 
     useMemo(() => {
         const tilesByCoords = kingdom.terrain.tiles.reduce((carry, tile) => {
@@ -46,8 +48,18 @@ const KingdomOverviewPage = () => {
     return <Page title="Kingdom" routes={[]}>
         <div className='kingdom-overview-page'>
             <h1>Overview</h1>
-            <div className='kingdom-overview-page__grid' style={styles}>
-                {orderedTiles.map(tile => <Tile key={tile.x + "-" + tile.y} type={tile.type} />)}
+            <div className='kingdom-overview-page__content'>
+                <div className='kingdom-overview-page__grid' style={styles}>
+                    {orderedTiles.map(tile => {
+                        return <Tile
+                            key={tile.x + "-" + tile.y}
+                            type={tile.type}
+                            onClick={() => setCurrentTile({...tile})} />;
+                    })}
+                </div>
+                <div className='kingdom-overview-page__tile-details'>
+                    {currentTile && <TileDetails tile={currentTile} />}
+                </div>
             </div>
         </div>
     </Page>;

--- a/src/Kingdom/Overview/Tile.tsx
+++ b/src/Kingdom/Overview/Tile.tsx
@@ -2,14 +2,15 @@ import './tile.css';
 
 type Props = {
     type: string;
+    onClick: () => void;
 };
 
 export const Tile = (props: Props) => {
-    const { type } = props;
+    const { type, onClick } = props;
 
     const classNames = "tile " + "tile--" + type.toLowerCase();
 
-    return <div className={classNames}>
+    return <div className={classNames} onClick={onClick}>
         {""}
     </div>
 };

--- a/src/Kingdom/Overview/TileDetails.tsx
+++ b/src/Kingdom/Overview/TileDetails.tsx
@@ -1,5 +1,5 @@
 import { Card } from "../../SharedComponents/Card/Card";
-import { Tile } from "./KingdomOverviewPage";
+import { Tile } from "./domain/types";
 
 type Props = {
     tile: Tile;

--- a/src/Kingdom/Overview/TileDetails.tsx
+++ b/src/Kingdom/Overview/TileDetails.tsx
@@ -1,0 +1,12 @@
+import { Card } from "../../SharedComponents/Card/Card";
+
+export const TileDetails = () => {
+    return <Card title="Tile">
+        <div>
+            Terrain features
+        </div>
+        <div>
+            Buildings
+        </div>
+    </Card>;
+};

--- a/src/Kingdom/Overview/TileDetails.tsx
+++ b/src/Kingdom/Overview/TileDetails.tsx
@@ -1,7 +1,14 @@
 import { Card } from "../../SharedComponents/Card/Card";
+import { Tile } from "./KingdomOverviewPage";
 
-export const TileDetails = () => {
-    return <Card title="Tile">
+type Props = {
+    tile: Tile;
+};
+
+export const TileDetails = (props: Props) => {
+    const { tile } = props;
+
+    return <Card title={tile.type}>
         <div>
             Terrain features
         </div>

--- a/src/Kingdom/Overview/TileDetails.tsx
+++ b/src/Kingdom/Overview/TileDetails.tsx
@@ -10,7 +10,8 @@ export const TileDetails = (props: Props) => {
 
     return <Card title={tile.type}>
         <div>
-            Terrain features
+            Terrain Traits
+            {tile.traits.map(trait => <div key={trait}>{trait}</div>)}
         </div>
         <div>
             Buildings

--- a/src/Kingdom/Overview/domain/addTerrainFeatures.ts
+++ b/src/Kingdom/Overview/domain/addTerrainFeatures.ts
@@ -1,5 +1,22 @@
-import { Tile } from "./types";
+import { getNeighboringTiles } from "../util";
+import { Terrain, Tile } from "./types";
 
-export const addTerrainFeatures = (tiles: Array<Tile>) => {
+export const addTerrainFeatures = (terrain: Terrain): Terrain => {
+    const tilesWithFeatures: Array<Tile> = terrain.tiles.map((tile) => {
+        const neighboringTiles = getNeighboringTiles(tile.x, tile.y, terrain.tiles);
 
+        return { ...tile };
+    });
+
+    return {...terrain, tiles: tilesWithFeatures};
 };
+
+// Adding terrain features
+//      criteria:
+//          surrounding tile types.
+//          percent chance to happen.
+//          current tile type.
+// If the criteria is true, then the trait is applied.
+// Example:
+//      If there are three surrounding Prairie tiles, and the current tile is a prairie, and we "rolled" over 70% then
+//          the Prairie has the "Rich Soil" trait. 

--- a/src/Kingdom/Overview/domain/addTerrainFeatures.ts
+++ b/src/Kingdom/Overview/domain/addTerrainFeatures.ts
@@ -1,22 +1,83 @@
 import { getNeighboringTiles } from "../util";
-import { Terrain, Tile } from "./types";
+import { Terrain, Tile, Trait } from "./types";
 
 export const addTerrainFeatures = (terrain: Terrain): Terrain => {
     const tilesWithFeatures: Array<Tile> = terrain.tiles.map((tile) => {
         const neighboringTiles = getNeighboringTiles(tile.x, tile.y, terrain.tiles);
 
-        return { ...tile };
+        const neighboringTilesTotals = neighboringTiles.reduce((carry, tile) => {
+            const currentTile = carry[tile.type];
+            if (currentTile) {
+                carry[tile.type] = currentTile + 1;
+            } else {
+                carry[tile.type] = 1;
+            }
+
+            return carry;
+        }, {} as {[key: string]: number|undefined});
+
+        const traitsToAssign = traits.filter((trait) => {
+            const { criteria } = trait;
+
+            if (tile.type !== criteria.currentTileType) {
+                return false;
+            }
+
+            if ((Math.random() * 100) > criteria.percentChance) {
+                return false;
+            }
+
+            const surroundingTileCriteria = trait.criteria.surroundingTileTypeCount;
+            if (!surroundingTileCriteria) {
+                return false;
+            }
+
+            const total = neighboringTilesTotals[surroundingTileCriteria.type];
+
+            if (!total) {
+                return false;
+            }
+
+            return total >= surroundingTileCriteria.threshold;
+        }).map(trait => trait.traitName);
+
+        return { ...tile, traits: [...traitsToAssign] };
     });
 
     return {...terrain, tiles: tilesWithFeatures};
 };
 
-// Adding terrain features
-//      criteria:
-//          surrounding tile types.
-//          percent chance to happen.
-//          current tile type.
-// If the criteria is true, then the trait is applied.
-// Example:
-//      If there are three surrounding Prairie tiles, and the current tile is a prairie, and we "rolled" over 70% then
-//          the Prairie has the "Rich Soil" trait. 
+const traits: Array<Trait> = [
+    {
+        traitName: "Rich Soil",
+        criteria: {
+            currentTileType: "Prairie",
+            surroundingTileTypeCount: {type: "prairie", threshold: 3 },
+            percentChance: 50
+        },
+    },
+    {
+        traitName: "Poor Soil",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 100
+        },
+    },
+    {
+        traitName: "Resource Rich",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 100
+        },
+    },
+    {
+        traitName: "Dense Woodland",
+        criteria: {
+            currentTileType: "Forest",
+            surroundingTileTypeCount: {type: "Forest", threshold: 3 },
+            percentChance: 50
+        },
+    },
+];

--- a/src/Kingdom/Overview/domain/addTerrainFeatures.ts
+++ b/src/Kingdom/Overview/domain/addTerrainFeatures.ts
@@ -52,8 +52,24 @@ const traits: Array<Trait> = [
         traitName: "Rich Soil",
         criteria: {
             currentTileType: "Prairie",
-            surroundingTileTypeCount: {type: "Prairie", threshold: 3 },
+            surroundingTileTypeCount: {type: "Prairie", threshold: 4},
+            percentChance: 100
+        },
+    },
+    {
+        traitName: "Wild Horses",
+        criteria: {
+            currentTileType: "Prairie",
+            surroundingTileTypeCount: {type: "Prairie", threshold: 2},
             percentChance: 50
+        },
+    },
+    {
+        traitName: "Wild Buffalo",
+        criteria: {
+            currentTileType: "Prairie",
+            surroundingTileTypeCount: {type: "Prairie", threshold: 2},
+            percentChance: 25
         },
     },
     {
@@ -65,7 +81,7 @@ const traits: Array<Trait> = [
         },
     },
     {
-        traitName: "Resource Rich",
+        traitName: "Resource: Stone",
         criteria: {
             currentTileType: "Mountain",
             surroundingTileTypeCount: null,
@@ -73,11 +89,83 @@ const traits: Array<Trait> = [
         },
     },
     {
+        traitName: "Resource: Iron",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 25
+        },
+    },
+    {
+        traitName: "Resource: Copper",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 25
+        },
+    },
+    {
+        traitName: "Resource: Coal",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 25
+        },
+    },
+    {
+        traitName: "Resource: Tin",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 25
+        },
+    },
+    {
+        traitName: "Resource: Gold",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 10
+        },
+    },
+    {
+        traitName: "Resource: Mithril",
+        criteria: {
+            currentTileType: "Mountain",
+            surroundingTileTypeCount: null,
+            percentChance: 5
+        },
+    },
+    {
         traitName: "Dense Woodland",
         criteria: {
             currentTileType: "Forest",
-            surroundingTileTypeCount: {type: "Forest", threshold: 4 },
+            surroundingTileTypeCount: {type: "Forest", threshold: 6},
+            percentChance: 75
+        },
+    },
+    {
+        traitName: "Dangerous Wildlife",
+        criteria: {
+            currentTileType: "Forest",
+            surroundingTileTypeCount: {type: "Forest", threshold: 4},
+            percentChance: 75
+        },
+    },
+    {
+        traitName: "Faerie Grove",
+        criteria: {
+            currentTileType: "Forest",
+            surroundingTileTypeCount: {type: "Forest", threshold: 8},
             percentChance: 50
+        },
+    },
+    {
+        traitName: "Witch's Lair",
+        criteria: {
+            currentTileType: "Swamp",
+            surroundingTileTypeCount: {type: "Swamp", threshold: 2},
+            percentChance: 10
         },
     },
 ];

--- a/src/Kingdom/Overview/domain/addTerrainFeatures.ts
+++ b/src/Kingdom/Overview/domain/addTerrainFeatures.ts
@@ -19,7 +19,7 @@ export const addTerrainFeatures = (terrain: Terrain): Terrain => {
         const traitsToAssign = traits.filter((trait) => {
             const { criteria } = trait;
 
-            if (tile.type !== criteria.currentTileType) {
+            if (tile.type !== criteria.currentTileType && criteria.currentTileType !== null) {
                 return false;
             }
 
@@ -28,8 +28,8 @@ export const addTerrainFeatures = (terrain: Terrain): Terrain => {
             }
 
             const surroundingTileCriteria = trait.criteria.surroundingTileTypeCount;
-            if (!surroundingTileCriteria) {
-                return false;
+            if (surroundingTileCriteria === null) {
+                return true;
             }
 
             const total = neighboringTilesTotals[surroundingTileCriteria.type];
@@ -52,7 +52,7 @@ const traits: Array<Trait> = [
         traitName: "Rich Soil",
         criteria: {
             currentTileType: "Prairie",
-            surroundingTileTypeCount: {type: "prairie", threshold: 3 },
+            surroundingTileTypeCount: {type: "Prairie", threshold: 3 },
             percentChance: 50
         },
     },
@@ -76,7 +76,7 @@ const traits: Array<Trait> = [
         traitName: "Dense Woodland",
         criteria: {
             currentTileType: "Forest",
-            surroundingTileTypeCount: {type: "Forest", threshold: 3 },
+            surroundingTileTypeCount: {type: "Forest", threshold: 4 },
             percentChance: 50
         },
     },

--- a/src/Kingdom/Overview/domain/addTerrainFeatures.ts
+++ b/src/Kingdom/Overview/domain/addTerrainFeatures.ts
@@ -1,0 +1,5 @@
+import { Tile } from "./types";
+
+export const addTerrainFeatures = (tiles: Array<Tile>) => {
+
+};

--- a/src/Kingdom/Overview/domain/types.ts
+++ b/src/Kingdom/Overview/domain/types.ts
@@ -1,3 +1,20 @@
 export type Kingdom = { name: String, terrain: Terrain };
 export type Terrain = { rowSize: number, columnSize: number, tiles: Array<Tile> };
-export type Tile = { id: string, x: number, y: number, type: string };
+export type Tile = {
+    id: string;
+    x: number;
+    y: number;
+    type: string;
+    traits: Array<string>;
+};
+
+export type Criteria = {
+    currentTileType: string|null;
+    surroundingTileTypeCount: { type: string, threshold: number } | null;
+    percentChance: number;
+};
+
+export type Trait = {
+    criteria: Criteria;
+    traitName: string;
+}

--- a/src/Kingdom/Overview/domain/types.ts
+++ b/src/Kingdom/Overview/domain/types.ts
@@ -1,0 +1,3 @@
+export type Kingdom = { name: String, terrain: Terrain };
+export type Terrain = { rowSize: number, columnSize: number, tiles: Array<Tile> };
+export type Tile = { id: string, x: number, y: number, type: string };

--- a/src/Kingdom/Overview/kingdom-overview-page.css
+++ b/src/Kingdom/Overview/kingdom-overview-page.css
@@ -4,10 +4,19 @@
     width: 100%;
 }
 
+.kingdom-overview-page__content {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
 .kingdom-overview-page__grid {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     width: fit-content;
+    height: fit-content;
+
+    align-self: center;
 
     text-align: center;
     gap: 4px;

--- a/src/Kingdom/Overview/tile.css
+++ b/src/Kingdom/Overview/tile.css
@@ -1,6 +1,15 @@
 .tile {
     height: 50px;
     width: 50px;
+    transition: all 0.1s ease-in-out;
+}
+.tile:hover {
+    transform: scale(1.1);
+    border: 1px dashed #FCFEFF;
+}
+.tile:active {
+    transform: translateY(-1px);
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
 
 .tile--prairie {

--- a/src/Kingdom/Overview/util.ts
+++ b/src/Kingdom/Overview/util.ts
@@ -7,7 +7,7 @@ export function generateWeightedTerrain(rowSize: number, columnSize: number, til
         for (let y = 0; y < columnSize; y++) {
             const neighboringTiles = getNeighboringTiles(x, y, tiles);
             const terrainType = determineTerrain(neighboringTiles);
-            tiles.push({ x, y, type: terrainType });
+            tiles.push({ id: crypto.randomUUID(), x, y, type: terrainType });
         }
     }
 

--- a/src/Kingdom/Overview/util.ts
+++ b/src/Kingdom/Overview/util.ts
@@ -1,7 +1,7 @@
 import { Terrain, Tile } from "./KingdomOverviewPage";
 
-export function generateWeightedTerrain(rowSize: number, columnSize: number): Terrain {
-    const tiles: Array<Tile> = [];
+export function generateWeightedTerrain(rowSize: number, columnSize: number, tilez?: Array<Tile>): Terrain {
+    const tiles: Array<Tile> = tilez ?? [];
 
     for (let x = 0; x < rowSize; x++) {
         for (let y = 0; y < columnSize; y++) {
@@ -31,18 +31,18 @@ function determineTerrain(neighboringTiles: Array<Tile>): string {
         "Swamp": 1,
     };
 
-    neighboringTiles.forEach(tile => {
-        switch (tile.type) {
+    neighboringTiles.forEach(neighboringTile => {
+        switch (neighboringTile.type) {
             case "Prairie":
-                terrainWeights[tile.type] += 2;
+                terrainWeights[neighboringTile.type] += 2;
                 break;
             case "Mountain":
             case "Swamp":
-                terrainWeights[tile.type] += 0.5;
+                terrainWeights[neighboringTile.type] += 0.5;
                 break;
             case "Forest":
             default:
-                terrainWeights[tile.type] += 1;
+                terrainWeights[neighboringTile.type] += 1;
                 break;
         }
     });

--- a/src/Kingdom/Overview/util.ts
+++ b/src/Kingdom/Overview/util.ts
@@ -16,10 +16,14 @@ export function generateWeightedTerrain(rowSize: number, columnSize: number, til
 
 export function getNeighboringTiles(x: number, y: number, tiles: Array<Tile>): Tile[] {
     return tiles.filter(tile =>
-        (tile.x === x - 1 && tile.y === y)              // Left
-        || (tile.x === x - 1 && tile.y === y - 1)       // Left-up
-        || (tile.x === x && tile.y === y - 1)           // Up
+        (tile.x === x && tile.y === y - 1)              // Up
         || (tile.x === x + 1 && tile.y === y - 1)       // Up-right
+        || (tile.x === x + 1 && tile.y === y)           // Right
+        || (tile.x === x + 1 && tile.y === y + 1)       // Down-right
+        || (tile.x === x && tile.y === y + 1)           // Down
+        || (tile.x === x - 1 && tile.y === y + 1)       // Down
+        || (tile.x === x - 1 && tile.y === y)           // Left
+        || (tile.x === x - 1 && tile.y === y - 1)       // Left-up
     );
 }
 

--- a/src/Kingdom/Overview/util.ts
+++ b/src/Kingdom/Overview/util.ts
@@ -1,4 +1,4 @@
-import { Terrain, Tile } from "./KingdomOverviewPage";
+import { Terrain, Tile } from "./domain/types";
 
 export function generateWeightedTerrain(rowSize: number, columnSize: number, tilez?: Array<Tile>): Terrain {
     const tiles: Array<Tile> = tilez ?? [];

--- a/src/Kingdom/Overview/util.ts
+++ b/src/Kingdom/Overview/util.ts
@@ -14,7 +14,7 @@ export function generateWeightedTerrain(rowSize: number, columnSize: number, til
     return { rowSize, columnSize, tiles };
 }
 
-function getNeighboringTiles(x: number, y: number, tiles: Array<Tile>): Tile[] {
+export function getNeighboringTiles(x: number, y: number, tiles: Array<Tile>): Tile[] {
     return tiles.filter(tile =>
         (tile.x === x - 1 && tile.y === y)      // Left
         || (tile.x === x + 1 && tile.y === y)   // Right

--- a/src/Kingdom/Overview/util.ts
+++ b/src/Kingdom/Overview/util.ts
@@ -7,7 +7,7 @@ export function generateWeightedTerrain(rowSize: number, columnSize: number, til
         for (let y = 0; y < columnSize; y++) {
             const neighboringTiles = getNeighboringTiles(x, y, tiles);
             const terrainType = determineTerrain(neighboringTiles);
-            tiles.push({ id: crypto.randomUUID(), x, y, type: terrainType });
+            tiles.push({ id: crypto.randomUUID(), x, y, type: terrainType, traits: [] });
         }
     }
 
@@ -16,10 +16,10 @@ export function generateWeightedTerrain(rowSize: number, columnSize: number, til
 
 export function getNeighboringTiles(x: number, y: number, tiles: Array<Tile>): Tile[] {
     return tiles.filter(tile =>
-        (tile.x === x - 1 && tile.y === y)      // Left
-        || (tile.x === x + 1 && tile.y === y)   // Right
-        || (tile.x === x && tile.y === y - 1)   // Up
-        || (tile.x === x && tile.y === y + 1)   // Down
+        (tile.x === x - 1 && tile.y === y)              // Left
+        || (tile.x === x - 1 && tile.y === y - 1)       // Left-up
+        || (tile.x === x && tile.y === y - 1)           // Up
+        || (tile.x === x + 1 && tile.y === y - 1)       // Up-right
     );
 }
 
@@ -42,7 +42,7 @@ function determineTerrain(neighboringTiles: Array<Tile>): string {
                 break;
             case "Forest":
             default:
-                terrainWeights[neighboringTile.type] += 1;
+                terrainWeights[neighboringTile.type] += 2;
                 break;
         }
     });


### PR DESCRIPTION
Resolves #72

Added a layer of trait generation to the grid. There's a lot of potential here - some ideas for the future features:
 * Second-pass trait generation.
 * Accounting for different types of surrounding tiles (for example, one may want to count forest and swamp tiles as the same thing for the purposes of spawning a wildlife resource).
 * Categorization of traits. For example, one may want to classify Copper and Iron traits as both being resources.